### PR TITLE
fix: workaround for jumpy transitions (known FF bug)

### DIFF
--- a/build/image-gallery.js
+++ b/build/image-gallery.js
@@ -84,7 +84,7 @@ var ImageGallery = function (_React$Component) {
             }
             return {
               zIndex: zIndex,
-              transition: 'transform ' + slideDuration + 'ms ' + timingFn + ' ' + delay + 'ms'
+              transition: 'transform ' + slideDuration + 'ms ' + timingFn + ' ' + delay + 'ms '
             };
           } else {
             return {
@@ -907,10 +907,10 @@ var ImageGallery = function (_React$Component) {
         translateX = this._getTranslateXForTwoSlide(index);
       }
 
-      var translate = 'translate(' + translateX + '%, 0)';
+      var translate = 'translate(' + translateX + '%, 0) rotate(0.0001deg)';
 
       if (useTranslate3D) {
-        translate = 'translate3d(' + translateX + '%, 0, 0)';
+        translate = 'translate3d(' + translateX + '%, 0, 0) rotate(0.0001deg)';
       }
 
       var styles = {

--- a/src/ImageGallery.jsx
+++ b/src/ImageGallery.jsx
@@ -866,10 +866,12 @@ export default class ImageGallery extends React.Component {
       translateX = this._getTranslateXForTwoSlide(index);
     }
 
-    let translate = `translate(${translateX}%, 0)`;
+    // hacky fix for jumping transitions in firefox
+    // https://stackoverflow.com/a/24855601/9037749
+    let translate = `translate(${translateX}%, 0) rotate(0.0001deg)`;
 
     if (useTranslate3D) {
-      translate = `translate3d(${translateX}%, 0, 0)`;
+      translate = `translate3d(${translateX}%, 0, 0) rotate(0.0001deg)`;
     }
 
     let styles = {


### PR DESCRIPTION
This is a workaround for Firefox bug https://bugzilla.mozilla.org/show_bug.cgi?id=739176