### PR TITLE
fix: add distinct item index

### DIFF
--- a/src/ImageGallery.jsx
+++ b/src/ImageGallery.jsx
@@ -999,7 +999,7 @@ export default class ImageGallery extends React.Component {
 
       const slide = (
         <div
-          key={index}
+          key={item.original + index}
           className={'image-gallery-slide' + alignment + originalClass}
           style={Object.assign(slideStyle, this.state.style)}
           onClick={this.props.onClick}


### PR DESCRIPTION
Quick fix to use distinct keys for the gallery items instead of the array index. That is considered bad practice (in most cases).